### PR TITLE
autompc.control.nmpc: fix broken and unused include

### DIFF
--- a/autompc/control/nmpc.py
+++ b/autompc/control/nmpc.py
@@ -1,4 +1,3 @@
-from collections import Iterable
 from .controller import Controller, ControllerFactory
 from pdb import set_trace
 import ConfigSpace as CS


### PR DESCRIPTION
## Description

The Sphinx documentation generation issues many warnings.  One of them appears to be missing optional dependencies even though I installed all dependencies and optional dependencies into a Conda environment:

```
Missing optional dependency for NMPC
[...]
WARNING: autodoc: failed to import class 'DirectTranscriptionControllerFactory' from module 'autompc.control'; the following exception was raised:
Traceback (most recent call last):
  File "/home/bentley/miniconda3/envs/autompc/lib/python3.10/site-packages/sphinx/util/inspect.py", line 440, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'autompc.control' has no attribute 'DirectTranscriptionControllerFactory'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/bentley/miniconda3/envs/autompc/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 102, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/home/bentley/miniconda3/envs/autompc/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 327, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/home/bentley/miniconda3/envs/autompc/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 2827, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/bentley/miniconda3/envs/autompc/lib/python3.10/site-packages/sphinx/util/inspect.py", line 456, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: DirectTranscriptionControllerFactory
```

Investigating further, the `DirectTranscriptionControllerFactory` class is included from `autompc/control/__init__.py` like so

```{python}
try:
    from .nmpc import DirectTranscriptionController, DirectTranscriptionControllerFactory
except ImportError:
    print("Missing optional dependency for NMPC")
```

It turns out this `try..except` block was hiding a bug because the include that failed to import was

```{python}
from collections import Iterable
```

The `Iterable` class is in `collections.abc`, not `collections`.  Further, this `Iterable` class is not used in the file at all.

## Proposed solution

Remove the inclusion of `Iterable` in `autompc/control/nmpc.py`